### PR TITLE
Add all nested taxon products to sale (Spree 3.1)

### DIFF
--- a/app/services/sale_creator.rb
+++ b/app/services/sale_creator.rb
@@ -87,9 +87,8 @@ class SaleCreator
   end
 
   def nested_products(taxon_id)
-    top_taxon = Spree::Taxon.find(taxon_id)
-    children_taxon_ids = top_taxon.taxonomy.taxons.pluck(:id)
-    all_taxon_ids = [top_taxon.id] + children_taxon_ids
+    parent_taxon = Spree::Taxon.find(taxon_id)
+    all_taxon_ids = parent_taxon.self_and_descendants.pluck(:id)
     Spree::ProductsTaxon.where(taxon_id: all_taxon_ids)
   end
 

--- a/app/services/sale_creator.rb
+++ b/app/services/sale_creator.rb
@@ -78,10 +78,19 @@ class SaleCreator
       product_ids = []
       product_ids.concat sale_params[:product_ids]
       if sale_params[:taxon_ids].any?
-        product_ids.concat Spree::ProductsTaxon.where(taxon_id: sale_params[:taxon_ids]).pluck(:product_id)
+        sale_params[:taxon_ids].each do |taxon_id|
+          product_ids.concat nested_products(taxon_id).pluck(:product_id)
+        end
       end
       product_ids
     end
+  end
+
+  def nested_products(taxon_id)
+    top_taxon = Spree::Taxon.find(taxon_id)
+    children_taxon_ids = top_taxon.taxonomy.taxons.pluck(:id)
+    all_taxon_ids = [top_taxon.id] + children_taxon_ids
+    Spree::ProductsTaxon.where(taxon_id: all_taxon_ids)
   end
 
   def users

--- a/app/services/sale_creator.rb
+++ b/app/services/sale_creator.rb
@@ -79,17 +79,17 @@ class SaleCreator
       product_ids.concat sale_params[:product_ids]
       if sale_params[:taxon_ids].any?
         sale_params[:taxon_ids].each do |taxon_id|
-          product_ids.concat nested_products(taxon_id).pluck(:product_id)
+          product_ids.concat nested_product_ids(taxon_id)
         end
       end
       product_ids
     end
   end
 
-  def nested_products(taxon_id)
+  def nested_product_ids(taxon_id)
     parent_taxon = Spree::Taxon.find(taxon_id)
     all_taxon_ids = parent_taxon.self_and_descendants.pluck(:id)
-    Spree::ProductsTaxon.where(taxon_id: all_taxon_ids)
+    Spree::ProductsTaxon.where(taxon_id: all_taxon_ids).pluck(:product_id).uniq
   end
 
   def users


### PR DESCRIPTION
When you choose a taxon to include in a sale all the nested taxons with their products will be included as well.